### PR TITLE
Enable Laravel 12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-tasks` will be documented in this file
 
+## [1.0.0.3] - 2024-XX-XX
+### Added
+- Laravel 12 compatibility
+
 ## 1.0.0 - 201X-XX-XX
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Laravel simple Tasks
 
+This package provides simple task management for Laravel applications. It is
+compatible with Laravel versions 8 through 12.
+
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/michal78/laravel-tasks.svg?style=flat-square)](https://packagist.org/packages/michal78/laravel-tasks)
 [![Total Downloads](https://img.shields.io/packagist/dt/michal78/laravel-tasks.svg?style=flat-square)](https://packagist.org/packages/michal78/laravel-tasks)
 ![GitHub Actions](https://github.com/michal78/laravel-tasks/actions/workflows/main.yml/badge.svg)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "homepage": "https://github.com/michal78/laravel-tasks",
     "license": "MIT",
     "type": "library",
-    "version": "1.0.0.2",
+    "version": "1.0.0.3",
     "authors": [
         {
             "name": "Michal Skogemann",
@@ -17,11 +17,14 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0"
+        "php": "^7.4|^8.0|^8.1|^8.2",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/cache": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.0"
+        "orchestra/testbench": "^6.0 || ^10.0",
+        "phpunit/phpunit": "^9.0 || ^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- add compatibility with Laravel 12
- document Laravel 12 support

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a974c3260832ebc276283c42bcaaa