### PR TITLE
Add PHPUnit tests with Orchestra Testbench

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="Package Tests">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/HasTasksTest.php
+++ b/tests/HasTasksTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Michal78\Tasks\Tests;
+
+use Michal78\Tasks\Models\Task;
+
+class HasTasksTest extends TestCase
+{
+    public function test_model_can_create_and_retrieve_tasks()
+    {
+        $user = User::create(['name' => 'Test User']);
+
+        $task = $user->addTask(['name' => 'Test Task']);
+
+        $this->assertInstanceOf(Task::class, $task);
+        $this->assertEquals($user->id, $task->owner_id);
+        $this->assertEquals(User::class, $task->owner_class);
+
+        $this->assertCount(1, $user->tasks);
+        $this->assertTrue($user->tasks->first()->is($task));
+        $this->assertCount(1, $user->pendingTasks());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Michal78\Tasks\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Michal78\Tasks\TasksServiceProvider;
+
+abstract class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        // run package migrations
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            TasksServiceProvider::class,
+        ];
+    }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+    }
+}

--- a/tests/User.php
+++ b/tests/User.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Michal78\Tasks\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Michal78\Tasks\Traits\HasTasks;
+
+class User extends Model
+{
+    use HasTasks;
+
+    protected $table = 'users';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
## Summary
- set up PHPUnit config
- add base TestCase for running migrations
- create dummy User model and HasTasks tests using Orchestra Testbench

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bd1310718832ea7aa0a8a2892bb14