### PR TITLE
Initialize Faker with Danish locale

### DIFF
--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -11,15 +11,20 @@ use Michal78\Tasks\Models\Task;
 class TaskFactory extends Factory
 {
     /**
+     * Configure the factory's faker instance.
+     */
+    public function withFaker(): \Faker\Generator
+    {
+        return \Faker\Factory::create('da_DK');
+    }
+
+    /**
      * Define the model's default state.
      *
      * @return array<string, mixed>
      */
     public function definition(): array
     {
-        $this->faker->languageCode('da_DK');
-        $this->faker->locale('da_DK');
-
         return [
             'name' => fake()->name(),
             'description' => fake()->text(),


### PR DESCRIPTION
## Summary
- update `TaskFactory` to use Danish faker instance
- remove leftover locale settings

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd14fef70832e989149ff0a3f22d0