### PR TITLE
Fix misspelled comment

### DIFF
--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -10,7 +10,7 @@ class Task extends Model
 {
     use HasFactory;
 
-    // Statusses
+    // Statuses
     const STATUS_PENDING = 'pending';
     const STATUS_COMPLETED = 'completed';
     const STATUS_RUNNING = 'running';


### PR DESCRIPTION
## Summary
- correct the comment spelling in `Task` model

## Testing
- `php -l src/Models/Task.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd14c03e4832eaa0823e5b7dc6a62