### PR TITLE
Fix README import and code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ composer require michal78/laravel-tasks
 
 ```php
 // Add the HasTasks trait to your model
-use Michal78\LaravelTasks\Traits\HasTasks;
+use Michal78\Tasks\Traits\HasTasks;
 
 class User extends Model
 {
@@ -49,8 +49,6 @@ $user->tasks()->completed()->get();
 $user->tasks()->completed()->future()->get();
 ```
 
-```php
-```
 
 ### Testing (Not implemented yet)
 


### PR DESCRIPTION
## Summary
- update trait import path in the usage example
- remove an extra code block marker

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684bd1529128832eafbe3bc99049df8f