### PR TITLE
Add polymorphic owner test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ class User extends Model
     use HasTasks;
 }
 
+class Project extends Model
+{
+    use HasTasks;
+}
+
 // Create a task
 $user->addTask(
     [
@@ -35,6 +40,9 @@ $user->addTask(
         'due_date' => now()->addDays(7),
     ]
 );
+
+// You can also attach tasks to other models
+$project->addTask(['name' => 'Deploy new version']);
 
 // Get all tasks
 $user->tasks;

--- a/tests/HasTasksTest.php
+++ b/tests/HasTasksTest.php
@@ -20,4 +20,16 @@ class HasTasksTest extends TestCase
         $this->assertTrue($user->tasks->first()->is($task));
         $this->assertCount(1, $user->pendingTasks());
     }
+
+    public function test_task_owner_is_polymorphic()
+    {
+        $project = Project::create(['name' => 'Test Project']);
+
+        $task = $project->addTask(['name' => 'Project Task']);
+
+        $this->assertInstanceOf(Task::class, $task);
+        $this->assertEquals($project->id, $task->owner_id);
+        $this->assertEquals(Project::class, $task->owner_class);
+        $this->assertTrue($task->owner->is($project));
+    }
 }

--- a/tests/Project.php
+++ b/tests/Project.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Michal78\Tasks\Tests;
+
+use Illuminate\Database\Eloquent\Model;
+use Michal78\Tasks\Traits\HasTasks;
+
+class Project extends Model
+{
+    use HasTasks;
+
+    protected $table = 'projects';
+
+    protected $guarded = [];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,12 @@ abstract class TestCase extends Orchestra
             $table->timestamps();
         });
 
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
         // run package migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }


### PR DESCRIPTION
## Summary
- demonstrate attaching tasks to multiple models in README
- add a `Project` model for testing
- ensure migrations create `projects` table for tests
- test that task owner is polymorphic

## Testing
- `vendor/bin/phpunit --filter=HasTasksTest` *(fails: `vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684bd3dcb340832ebf7f9e3ae05d850c