### PR TITLE
Fix README import statement and code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ composer require michal78/laravel-tasks
 
 ```php
 // Add the HasTasks trait to your model
-use Michal78\LaravelTasks\Traits\HasTasks;
+use Michal78\Tasks\Traits\HasTasks;
 
 class User extends Model
 {
@@ -49,8 +49,6 @@ $user->tasks()->completed()->get();
 $user->tasks()->completed()->future()->get();
 ```
 
-```php
-```
 
 ### Testing (Not implemented yet)
 


### PR DESCRIPTION
## Summary
- correct trait namespace in README
- remove stray code block start from README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bd2b86894832ebf98a302074c4744