### PR TITLE
Add task scheduler command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,23 @@ $user->tasks()->completed()->get();
 
 // Get all tasks that are completed and have a due date in the future
 $user->tasks()->completed()->future()->get();
+
+// Schedule a job for a task
+$user->addTask([
+    'name' => 'Cleanup',
+    'job' => \App\Jobs\CleanupJob::class,
+    'job_data' => json_encode(['force' => true]),
+    'due_date' => now()->addMinutes(10),
+]);
 ```
+
+Run the dispatcher command manually if needed:
+
+```bash
+php artisan tasks:dispatch
+```
+
+When `TASKS_AUTO_SCHEDULE` is enabled (the default), this command is automatically scheduled to run every minute.
 
 
 ### Testing (Not implemented yet)

--- a/src/Console/Commands/DispatchDueTasksCommand.php
+++ b/src/Console/Commands/DispatchDueTasksCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Michal78\Tasks\Console\Commands;
+
+use Illuminate\Console\Command;
+use Michal78\Tasks\Models\Task;
+use Illuminate\Support\Facades\Bus;
+
+class DispatchDueTasksCommand extends Command
+{
+    protected $signature = 'tasks:dispatch';
+    protected $description = 'Dispatch all due tasks';
+
+    public function handle(): int
+    {
+        $tasks = Task::where('status', Task::STATUS_PENDING)
+            ->whereNotNull('job')
+            ->whereNotNull('due_date')
+            ->where('due_date', '<=', now())
+            ->get();
+
+        foreach ($tasks as $task) {
+            $job = new $task->job($task->job_data);
+            Bus::dispatch($job);
+
+            $task->status = Task::STATUS_RUNNING;
+            $task->save();
+        }
+
+        $this->info($tasks->count() . ' tasks dispatched.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/TasksServiceProvider.php
+++ b/src/TasksServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace Michal78\Tasks;
 
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\ServiceProvider;
+use Michal78\Tasks\Console\Commands\DispatchDueTasksCommand;
 
 class TasksServiceProvider extends ServiceProvider
 {
@@ -22,13 +24,17 @@ class TasksServiceProvider extends ServiceProvider
                 __DIR__.'/../config/config.php' => config_path('laravel-tasks.php'),
             ], 'config');
 
-            // Publishing the translation files.
-            /*$this->publishes([
-                __DIR__.'/../resources/lang' => resource_path('lang/vendor/laravel-tasks'),
-            ], 'lang');*/
+            // Register package command
+            $this->commands([
+                DispatchDueTasksCommand::class,
+            ]);
 
-            // Registering package commands.
-            // $this->commands([]);
+            if (config('laravel-tasks.auto_schedule')) {
+                $this->app->booted(function () {
+                    $schedule = $this->app->make(Schedule::class);
+                    $schedule->command('tasks:dispatch')->everyMinute();
+                });
+            }
         }
     }
 

--- a/tests/DispatchDueTasksCommandTest.php
+++ b/tests/DispatchDueTasksCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Michal78\Tasks\Tests;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Queue;
+use Michal78\Tasks\Models\Task;
+use Michal78\Tasks\Tests\Jobs\DummyJob;
+
+class DispatchDueTasksCommandTest extends TestCase
+{
+    public function test_command_dispatches_due_tasks()
+    {
+        Queue::fake();
+
+        $user = User::create(['name' => 'Test']);
+
+        $dueTask = $user->addTask([
+            'name' => 'Due',
+            'job' => DummyJob::class,
+            'job_data' => json_encode(['foo' => 'bar']),
+            'due_date' => now()->subMinute(),
+        ]);
+
+        $futureTask = $user->addTask([
+            'name' => 'Future',
+            'job' => DummyJob::class,
+            'due_date' => now()->addHour(),
+        ]);
+
+        Artisan::call('tasks:dispatch');
+
+        Queue::assertPushed(DummyJob::class, 1);
+        $this->assertEquals(Task::STATUS_RUNNING, $dueTask->fresh()->status);
+        $this->assertEquals(Task::STATUS_PENDING, $futureTask->fresh()->status);
+    }
+}

--- a/tests/Jobs/DummyJob.php
+++ b/tests/Jobs/DummyJob.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Michal78\Tasks\Tests\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DummyJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $data;
+
+    public function __construct($data = null)
+    {
+        $this->data = $data;
+    }
+
+    public function handle(): void
+    {
+        // no-op
+    }
+}


### PR DESCRIPTION
## Summary
- add a command to dispatch due tasks
- schedule `tasks:dispatch` when auto_schedule is enabled
- test the dispatcher command
- document how to schedule jobs for tasks

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfea9fcb4832eb4396edc8ceb0c71