### PR TITLE
Add model-driven scheduled tasks with optional task logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,155 @@
-# Laravel simple Tasks
+# Laravel Tasks
 
-This package provides simple task management for Laravel applications. It is
-compatible with Laravel versions 8 through 12.
+`michal78/laravel-tasks` lets you attach scheduled tasks to any Eloquent model.
+
+A task can run one of four target types at a specific time:
+
+- Artisan command
+- Action class
+- Event class
+- Service class method
+
+The model is always passed into the target, and task runs can be logged (optional).
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/michal78/laravel-tasks.svg?style=flat-square)](https://packagist.org/packages/michal78/laravel-tasks)
 [![Total Downloads](https://img.shields.io/packagist/dt/michal78/laravel-tasks.svg?style=flat-square)](https://packagist.org/packages/michal78/laravel-tasks)
-![GitHub Actions](https://github.com/michal78/laravel-tasks/actions/workflows/main.yml/badge.svg)
+
+## Requirements
+
+- PHP 8.2+
+- Laravel 11 or 12
 
 ## Installation
-
-You can install the package via composer:
 
 ```bash
 composer require michal78/laravel-tasks
 ```
 
-## Usage
+Run migrations:
+
+```bash
+php artisan migrate
+```
+
+Optional config publish:
+
+```bash
+php artisan vendor:publish --provider="Michal78\Tasks\TasksServiceProvider" --tag=config
+```
+
+## Model Setup
+
+Add the trait to any model:
 
 ```php
-// Add the HasTasks trait to your model
+use Illuminate\Database\Eloquent\Model;
 use Michal78\Tasks\Traits\HasTasks;
 
 class User extends Model
 {
     use HasTasks;
 }
-
-// Create a task
-$user->addTask(
-    [
-        'name' => 'My task',
-        'description' => 'My task description',
-        'priority' => 2,
-        'due_date' => now()->addDays(7),
-    ]
-);
-
-// Get all tasks
-$user->tasks;
-
-// Get all tasks that are not completed
-$user->tasks()->notCompleted()->get();
-
-// Get all tasks that are completed
-$user->tasks()->completed()->get();
-
-// Get all tasks that are completed and have a due date in the future
-$user->tasks()->completed()->future()->get();
 ```
 
+## Scheduling Tasks
 
-### Testing (Not implemented yet)
+### Command task
+
+```php
+$user->scheduleCommandTask(
+    name: 'Sync user',
+    command: 'users:sync',
+    runAt: now()->addMinutes(10),
+    payload: ['--force' => true],
+);
+```
+
+The package injects these command options automatically:
+
+- `--model-type` (model class)
+- `--model-id` (model primary key)
+
+### Action task
+
+```php
+$user->scheduleActionTask(
+    name: 'Run action',
+    actionClass: \App\Actions\UserAction::class,
+    runAt: now()->addHour(),
+    payload: ['source' => 'onboarding'],
+);
+```
+
+Default method is `__invoke`. You can pass a custom method with the `method` argument.
+
+### Event task
+
+```php
+$user->scheduleEventTask(
+    name: 'Dispatch event',
+    eventClass: \App\Events\UserTaskDue::class,
+    runAt: now()->addMinutes(30),
+    payload: ['channel' => 'email'],
+);
+```
+
+Event constructor signature should accept:
+
+```php
+public function __construct(Model $model, array $payload, Task $task)
+```
+
+### Service task
+
+```php
+$user->scheduleServiceTask(
+    name: 'Call service',
+    serviceClass: \App\Services\UserTaskService::class,
+    runAt: now()->addDay(),
+    payload: ['dry_run' => false],
+    method: 'handle', // optional, defaults to handle
+);
+```
+
+## Running Due Tasks
+
+The package registers:
+
+```bash
+php artisan tasks:run-due
+```
+
+Add it to Laravel scheduler:
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('tasks:run-due')->everyMinute();
+```
+
+## Task Logging (Optional)
+
+Each run can be logged in `task_logs`.
+
+Config:
+
+```php
+// config/laravel-tasks.php
+return [
+    'logging' => [
+        'enabled' => env('TASKS_LOGGING_ENABLED', true),
+    ],
+];
+```
+
+When enabled, each task run stores status (`running`, `succeeded`, `failed`), start/end timestamps, and optional error message.
+
+## Testing
 
 ```bash
 composer test
 ```
 
-### Changelog
-
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
-
-## Contributing
-
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
-
-### Security
-
-If you discover any security related issues, please email michal.skogemann@gmail.com instead of using the issue tracker.
-
-## Credits
-
--   [Michal Skogemann](https://github.com/michal78)
--   [All Contributors](../../contributors)
-
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+MIT

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "michal78/laravel-tasks",
-    "description": "Simple task management for Laravel",
+    "description": "Scheduled model tasks for Laravel",
     "keywords": [
         "michal78",
         "laravel-tasks"
@@ -17,14 +17,15 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0|^8.1|^8.2",
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/cache": "^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0"
+        "php": "^8.2",
+        "illuminate/console": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0",
+        "illuminate/cache": "^11.0|^12.0",
+        "illuminate/database": "^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0 || ^10.0",
-        "phpunit/phpunit": "^9.0 || ^10.0"
+        "orchestra/testbench": "^9.0 || ^10.0",
+        "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/config.php
+++ b/config/config.php
@@ -1,11 +1,7 @@
 <?php
 
-/*
- * Config
- */
 return [
-    'country' => env('TASKS_COUNTRY', 'DK'),
-    'task_language' => env('TASKS_LANGUAGE', 'DA'),
-    'auto_schedule' => env('TASKS_AUTO_SCHEDULE', true),
-    'auto_migrate' => env('TASKS_AUTO_MIGRATE', true),
+    'logging' => [
+        'enabled' => env('TASKS_LOGGING_ENABLED', true),
+    ],
 ];

--- a/database/factories/TaskFactory.php
+++ b/database/factories/TaskFactory.php
@@ -10,39 +10,27 @@ use Michal78\Tasks\Models\Task;
  */
 class TaskFactory extends Factory
 {
-    /**
-     * Configure the factory's faker instance.
-     */
-    public function withFaker(): \Faker\Generator
-    {
-        return \Faker\Factory::create('da_DK');
-    }
+    protected $model = Task::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'description' => fake()->text(),
-            'status' => fake()->randomElement([
-                Task::STATUS_PENDING,
-                Task::STATUS_COMPLETED,
-                Task::STATUS_RUNNING,
+            'name' => fake()->sentence(3),
+            'taskable_id' => 1,
+            'taskable_type' => 'App\\Models\\User',
+            'type' => fake()->randomElement([
+                Task::TYPE_ACTION,
+                Task::TYPE_COMMAND,
+                Task::TYPE_EVENT,
+                Task::TYPE_SERVICE,
             ]),
-            'owner_id' => 1,
-            'owner_class' => 'App\Models\User',
-            'assignee_id' => 1,
-            'assignee_class' => 'App\Models\User',
-            'due_date' => fake()->dateTimeBetween('-3 month', '+3 month'),
-            'priority' => fake()->numberBetween(0, 10),
-            'completed_at' => null,
-            'completed_by' => null,
-            'created_at' => fake()->dateTimeBetween('-3 month', '+3 month'),
-            'updated_at' => fake()->dateTimeBetween('-3 month', '+3 month'),
+            'target' => 'app:task',
+            'method' => null,
+            'payload' => ['example' => true],
+            'run_at' => now()->addMinute(),
+            'status' => Task::STATUS_PENDING,
+            'error_message' => null,
+            'last_ran_at' => null,
         ];
     }
 }

--- a/database/migrations/2023_05_18_113529_add_tasks_table.php
+++ b/database/migrations/2023_05_18_113529_add_tasks_table.php
@@ -3,34 +3,28 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Michal78\Tasks\Models\Task;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
         Schema::create('tasks', function (Blueprint $table) {
             $table->id();
+            $table->morphs('taskable');
             $table->string('name');
-            $table->text('description')->nullable();
-            $table->enum('status', ['pending', 'completed', 'running'])->default('pending');
-            $table->morphs('creator');
-            $table->morphs('assignee');
-            $table->string('job')->nullable();
-            $table->text('job_data')->nullable();
-            $table->timestamp('due_date')->nullable();
-            $table->integer('priority')->default(0);
-            $table->timestamp('completed_at')->nullable();
-            $table->unsignedBigInteger('completed_by')->nullable();
+            $table->string('type')->default(Task::TYPE_SERVICE);
+            $table->string('target');
+            $table->string('method')->nullable();
+            $table->json('payload')->nullable();
+            $table->timestamp('run_at')->index();
+            $table->string('status')->default(Task::STATUS_PENDING)->index();
+            $table->text('error_message')->nullable();
+            $table->timestamp('last_ran_at')->nullable();
             $table->timestamps();
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('tasks');

--- a/database/migrations/2026_04_11_101000_add_task_logs_table.php
+++ b/database/migrations/2026_04_11_101000_add_task_logs_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('task_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('task_id')->constrained('tasks')->cascadeOnDelete();
+            $table->string('status');
+            $table->timestamp('started_at');
+            $table->timestamp('finished_at')->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('task_logs');
+    }
+};

--- a/src/Commands/RunDueTasksCommand.php
+++ b/src/Commands/RunDueTasksCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Michal78\Tasks\Commands;
+
+use Illuminate\Console\Command;
+use Michal78\Tasks\Tasks;
+
+class RunDueTasksCommand extends Command
+{
+    protected $signature = 'tasks:run-due';
+
+    protected $description = 'Run all due model tasks';
+
+    public function handle(Tasks $tasks): int
+    {
+        $processed = $tasks->runDueTasks();
+
+        $this->info(sprintf('Processed %d due task(s).', $processed));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Models/Task.php
+++ b/src/Models/Task.php
@@ -2,281 +2,57 @@
 
 namespace Michal78\Tasks\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class Task extends Model
 {
-    use HasFactory;
+    public const TYPE_COMMAND = 'command';
+    public const TYPE_ACTION = 'action';
+    public const TYPE_EVENT = 'event';
+    public const TYPE_SERVICE = 'service';
 
-    // Statuses
-    const STATUS_PENDING = 'pending';
-    const STATUS_COMPLETED = 'completed';
-    const STATUS_RUNNING = 'running';
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_RUNNING = 'running';
+    public const STATUS_SUCCEEDED = 'succeeded';
+    public const STATUS_FAILED = 'failed';
 
-    protected array $fillable = [
+    protected $table = 'tasks';
+
+    protected $fillable = [
         'name',
-        'description',
+        'type',
+        'target',
+        'method',
+        'payload',
+        'run_at',
         'status',
-        'owner_id',
-        'owner_class',
-        'assignee_id',
-        'assignee_class',
-        'job',
-        'job_data',
-        'due_date',
-        'priority',
-        'completed_at',
-        'completed_by',
+        'error_message',
+        'last_ran_at',
     ];
 
-    public function owner(): MorphTo
+    protected $casts = [
+        'payload' => 'array',
+        'run_at' => 'datetime',
+        'last_ran_at' => 'datetime',
+    ];
+
+    public function taskable(): MorphTo
     {
         return $this->morphTo();
     }
 
-    /**
-     * @return MorphTo
-     */
-    public function assignee(): MorphTo
+    public function logs(): HasMany
     {
-        return $this->morphTo();
+        return $this->hasMany(TaskLog::class);
     }
 
-    /**
-     * @param Model $model
-     * @return Task
-     */
-    public function complete(Model $model): Task
+    public function scopeDue(Builder $query): Builder
     {
-        $this->status = self::STATUS_COMPLETED;
-        $this->completed_at = now();
-        $this->completed_by = $model->id;
-        $this->save();
-
-        return $this;
-    }
-
-
-    /**
-     * @param Model $model
-     * @return $this
-     */
-    public function assign(Model $model): Task
-    {
-        $this->assignee_id = $model->id;
-        $this->assignee_class = get_class($model);
-        $this->save();
-
-        return $this;
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopePending($query): mixed
-    {
-        return $query->whereNull('completed_at');
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeCompleted($query): mixed
-    {
-        return $query->whereNotNull('completed_at');
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeOverdue($query): mixed
-    {
-        return $query->where('due_date', '<', now());
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueToday($query): mixed
-    {
-        return $query->whereDate('due_date', '=', now());
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueTomorrow($query): mixed
-    {
-        return $query->whereDate('due_date', '=', now()->addDay());
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueThisWeek($query): mixed
-    {
-        return $query->whereBetween('due_date', [now()->startOfWeek(), now()->endOfWeek()]);
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueNextWeek($query): mixed
-    {
-        return $query->whereBetween('due_date', [now()->addWeek()->startOfWeek(), now()->addWeek()->endOfWeek()]);
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueThisMonth($query): mixed
-    {
-        return $query->whereBetween('due_date', [now()->startOfMonth(), now()->endOfMonth()]);
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueNextMonth($query): mixed
-    {
-        return $query->whereBetween('due_date', [now()->addMonth()->startOfMonth(), now()->addMonth()->endOfMonth()]);
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueThisYear($query): mixed
-    {
-        return $query->whereBetween('due_date', [now()->startOfYear(), now()->endOfYear()]);
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueNextYear($query): mixed
-    {
-        return $query->whereBetween('due_date', [now()->addYear()->startOfYear(), now()->addYear()->endOfYear()]);
-    }
-
-    /**
-     * @param $query
-     * @param $from
-     * @param $to
-     * @return mixed
-     */
-    public function scopeDueBetween($query, $from, $to): mixed
-    {
-        return $query->whereBetween('due_date', [$from, $to]);
-    }
-
-    /**
-     * @param $query
-     * @param $date
-     * @return mixed
-     */
-    public function scopeDueBefore($query, $date): mixed
-    {
-        return $query->where('due_date', '<', $date);
-    }
-
-    /**
-     * @param $query
-     * @param $date
-     * @return mixed
-     */
-    public function scopeDueAfter($query, $date): mixed
-    {
-        return $query->where('due_date', '>', $date);
-    }
-
-    /**
-     * @param $query
-     * @param $date
-     * @return mixed
-     */
-    public function scopeDueOn($query, $date): mixed
-    {
-        return $query->where('due_date', $date);
-    }
-
-    /**
-     * @param $query
-     * @param $date
-     * @return mixed
-     */
-    public function scopeDueOnOrBefore($query, $date): mixed
-    {
-        return $query->where('due_date', '<=', $date);
-    }
-
-    /**
-     * @param $query
-     * @param $date
-     * @return mixed
-     */
-    public function scopeDueOnOrAfter($query, $date): mixed
-    {
-        return $query->where('due_date', '>=', $date);
-    }
-
-    /**
-     * @param $query
-     * @param $from
-     * @param $to
-     * @return mixed
-     */
-    public function scopeDueOnOrBetween($query, $from, $to): mixed
-    {
-        return $query->whereBetween('due_date', [$from, $to]);
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueOnOrBeforeToday($query): mixed
-    {
-        return $query->whereDate('due_date', '<=', now());
-    }
-
-    /**
-     * @param $query
-     * @return mixed
-     */
-    public function scopeDueOnOrAfterToday($query): mixed
-    {
-        return $query->whereDate('due_date', '>=', now());
-    }
-
-    /**
-     * @param $date
-     * @return void
-     */
-    public function schedule($date): void
-    {
-        $job = $this->getJob();
-
-        $job->delay($date)->dispatch();
-    }
-
-    /**
-     * @return mixed
-     */
-    private function getJob(): mixed
-    {
-        return new $this->job($this->job_data);
+        return $query
+            ->where('status', self::STATUS_PENDING)
+            ->where('run_at', '<=', now());
     }
 }

--- a/src/Models/TaskLog.php
+++ b/src/Models/TaskLog.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Michal78\Tasks\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TaskLog extends Model
+{
+    protected $table = 'task_logs';
+
+    protected $fillable = [
+        'task_id',
+        'status',
+        'started_at',
+        'finished_at',
+        'error_message',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+    ];
+
+    public function task(): BelongsTo
+    {
+        return $this->belongsTo(Task::class);
+    }
+}

--- a/src/Support/TaskRunner.php
+++ b/src/Support/TaskRunner.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Michal78\Tasks\Support;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
+use Michal78\Tasks\Models\Task;
+use Michal78\Tasks\Models\TaskLog;
+use Throwable;
+
+class TaskRunner
+{
+    public function __construct(
+        protected Container $container,
+    ) {
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    public function run(Task $task): void
+    {
+        $task->forceFill([
+            'status' => Task::STATUS_RUNNING,
+        ])->save();
+
+        $log = $this->createLog($task);
+
+        try {
+            $this->execute($task);
+
+            $task->forceFill([
+                'status' => Task::STATUS_SUCCEEDED,
+                'last_ran_at' => now(),
+                'error_message' => null,
+            ])->save();
+
+            $this->finishLog($log, Task::STATUS_SUCCEEDED);
+        } catch (Throwable $exception) {
+            $task->forceFill([
+                'status' => Task::STATUS_FAILED,
+                'last_ran_at' => now(),
+                'error_message' => $exception->getMessage(),
+            ])->save();
+
+            $this->finishLog($log, Task::STATUS_FAILED, $exception->getMessage());
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    protected function execute(Task $task): void
+    {
+        $model = $task->taskable;
+        $payload = $task->payload ?? [];
+
+        match ($task->type) {
+            Task::TYPE_COMMAND => $this->runCommand($task, $model, $payload),
+            Task::TYPE_ACTION => $this->runAction($task, $model, $payload),
+            Task::TYPE_EVENT => $this->runEvent($task, $model, $payload),
+            Task::TYPE_SERVICE => $this->runService($task, $model, $payload),
+            default => throw new \RuntimeException("Unsupported task type [{$task->type}]"),
+        };
+    }
+
+    protected function runCommand(Task $task, object $model, array $payload): void
+    {
+        Artisan::call($task->target, array_merge($payload, [
+            '--model-type' => $model::class,
+            '--model-id' => (string) $model->getKey(),
+        ]));
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    protected function runAction(Task $task, object $model, array $payload): void
+    {
+        $action = $this->container->make($task->target);
+        $method = $task->method ?? '__invoke';
+
+        $this->container->call([$action, $method], [
+            'model' => $model,
+            'payload' => $payload,
+            'task' => $task,
+        ]);
+    }
+
+    protected function runEvent(Task $task, object $model, array $payload): void
+    {
+        $event = new $task->target($model, $payload, $task);
+        Event::dispatch($event);
+    }
+
+    /**
+     * @throws BindingResolutionException
+     */
+    protected function runService(Task $task, object $model, array $payload): void
+    {
+        $service = $this->container->make($task->target);
+        $method = $task->method ?: 'handle';
+
+        $this->container->call([$service, $method], [
+            'model' => $model,
+            'payload' => $payload,
+            'task' => $task,
+        ]);
+    }
+
+    protected function createLog(Task $task): ?TaskLog
+    {
+        if (! config('laravel-tasks.logging.enabled')) {
+            return null;
+        }
+
+        return $task->logs()->create([
+            'status' => Task::STATUS_RUNNING,
+            'started_at' => now(),
+        ]);
+    }
+
+    protected function finishLog(?TaskLog $log, string $status, ?string $errorMessage = null): void
+    {
+        if (! $log) {
+            return;
+        }
+
+        $log->forceFill([
+            'status' => $status,
+            'finished_at' => now(),
+            'error_message' => $errorMessage,
+        ])->save();
+    }
+}

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -2,28 +2,34 @@
 
 namespace Michal78\Tasks;
 
-use Carbon\Carbon;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\Eloquent\Collection;
+use Michal78\Tasks\Models\Task;
+use Michal78\Tasks\Support\TaskRunner;
 
 class Tasks
 {
-    public function addHolidays() {
-
+    public function __construct(
+        protected TaskRunner $taskRunner,
+    ) {
     }
 
-    /**
-     * @return Collection
-     */
-    public function getHolidays(): Collection
+    public function getDueTasks(): Collection
     {
-        $holidays = Cache::get('laravel-tasks.holidays');
+        return Task::query()
+            ->due()
+            ->orderBy('run_at')
+            ->get();
+    }
 
-        if(! $holidays) {
-            $holidays = file_get_contents('https://date.nager.at/api/v3/PublicHolidays/'.Carbon::now()->year.'/' . config('laravel-tasks.country'));
-            Cache::put('laravel-tasks.holidays', $holidays);
+    public function runDueTasks(): int
+    {
+        $processed = 0;
+
+        foreach ($this->getDueTasks() as $task) {
+            $this->taskRunner->run($task);
+            $processed++;
         }
 
-        return collect(json_decode($holidays));
+        return $processed;
     }
 }

--- a/src/TasksFacade.php
+++ b/src/TasksFacade.php
@@ -4,9 +4,6 @@ namespace Michal78\Tasks;
 
 use Illuminate\Support\Facades\Facade;
 
-/**
- * @see \Michal78\Tasks\Skeleton\SkeletonClass
- */
 class TasksFacade extends Facade
 {
     /**

--- a/src/TasksServiceProvider.php
+++ b/src/TasksServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Michal78\Tasks;
 
 use Illuminate\Support\ServiceProvider;
+use Michal78\Tasks\Commands\RunDueTasksCommand;
+use Michal78\Tasks\Support\TaskRunner;
 
 class TasksServiceProvider extends ServiceProvider
 {
@@ -40,9 +42,17 @@ class TasksServiceProvider extends ServiceProvider
         // Automatically apply the package configuration
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'laravel-tasks');
 
+        $this->app->singleton(TaskRunner::class);
+
         // Register the main class to use with the facade
-        $this->app->singleton('tasks', function () {
-            return new Tasks;
+        $this->app->singleton('tasks', function ($app) {
+            return new Tasks($app->make(TaskRunner::class));
         });
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                RunDueTasksCommand::class,
+            ]);
+        }
     }
 }

--- a/src/Traits/HasTasks.php
+++ b/src/Traits/HasTasks.php
@@ -2,40 +2,95 @@
 
 namespace Michal78\Tasks\Traits;
 
+use DateTimeInterface;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Michal78\Tasks\Models\Task;
 
 trait HasTasks
 {
-    // Add task
-    public function addTask($task)
-    {
-        return $this->tasks()->create($task);
-    }
-
-    // Get pending tasks
-    public function pendingTasks()
-    {
-        // Use scopes from Task model
-        return $this->tasks()->pending()->get();
-    }
-
-    // Get completed tasks
-    public function completedTasks()
-    {
-        // Use scopes from Task model
-        return $this->tasks()->completed()->get();
-    }
-
-    // Get all tasks
     public function tasks(): MorphMany
     {
-        return $this->morphMany('Michal78\Tasks\Models\Task', 'owner', 'owner_class');
+        return $this->morphMany(Task::class, 'taskable');
     }
 
-    // Complete task
-    public function completeTask(Task $task)
+    public function addTask(array $attributes): Task
     {
-        return $task->complete($this);
+        return $this->tasks()->create(array_merge([
+            'status' => Task::STATUS_PENDING,
+        ], $attributes));
+    }
+
+    public function scheduleCommandTask(
+        string $name,
+        string $command,
+        DateTimeInterface|string $runAt,
+        array $payload = [],
+    ): Task {
+        return $this->addTask([
+            'name' => $name,
+            'type' => Task::TYPE_COMMAND,
+            'target' => $command,
+            'payload' => $payload,
+            'run_at' => $runAt,
+        ]);
+    }
+
+    public function scheduleActionTask(
+        string $name,
+        string $actionClass,
+        DateTimeInterface|string $runAt,
+        array $payload = [],
+        ?string $method = null,
+    ): Task {
+        return $this->addTask([
+            'name' => $name,
+            'type' => Task::TYPE_ACTION,
+            'target' => $actionClass,
+            'method' => $method,
+            'payload' => $payload,
+            'run_at' => $runAt,
+        ]);
+    }
+
+    public function scheduleEventTask(
+        string $name,
+        string $eventClass,
+        DateTimeInterface|string $runAt,
+        array $payload = [],
+    ): Task {
+        return $this->addTask([
+            'name' => $name,
+            'type' => Task::TYPE_EVENT,
+            'target' => $eventClass,
+            'payload' => $payload,
+            'run_at' => $runAt,
+        ]);
+    }
+
+    public function scheduleServiceTask(
+        string $name,
+        string $serviceClass,
+        DateTimeInterface|string $runAt,
+        array $payload = [],
+        string $method = 'handle',
+    ): Task {
+        return $this->addTask([
+            'name' => $name,
+            'type' => Task::TYPE_SERVICE,
+            'target' => $serviceClass,
+            'method' => $method,
+            'payload' => $payload,
+            'run_at' => $runAt,
+        ]);
+    }
+
+    public function pendingTasks()
+    {
+        return $this->tasks()->where('status', Task::STATUS_PENDING)->get();
+    }
+
+    public function completedTasks()
+    {
+        return $this->tasks()->where('status', Task::STATUS_SUCCEEDED)->get();
     }
 }

--- a/tests/Fixtures/SampleAction.php
+++ b/tests/Fixtures/SampleAction.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Michal78\Tasks\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Michal78\Tasks\Models\Task;
+
+class SampleAction
+{
+    public static array $calls = [];
+
+    public function __invoke(Model $model, array $payload, Task $task): void
+    {
+        self::$calls[] = [
+            'model_id' => $model->getKey(),
+            'payload' => $payload,
+            'task_id' => $task->getKey(),
+        ];
+    }
+}

--- a/tests/Fixtures/SampleEvent.php
+++ b/tests/Fixtures/SampleEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Michal78\Tasks\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Michal78\Tasks\Models\Task;
+
+class SampleEvent
+{
+    public function __construct(
+        public Model $model,
+        public array $payload,
+        public Task $task,
+    ) {
+    }
+}

--- a/tests/Fixtures/SampleService.php
+++ b/tests/Fixtures/SampleService.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Michal78\Tasks\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+use Michal78\Tasks\Models\Task;
+
+class SampleService
+{
+    public static array $calls = [];
+
+    public function handle(Model $model, array $payload, Task $task): void
+    {
+        self::$calls[] = [
+            'model_id' => $model->getKey(),
+            'payload' => $payload,
+            'task_id' => $task->getKey(),
+            'method' => 'handle',
+        ];
+    }
+
+    public function run(Model $model, array $payload, Task $task): void
+    {
+        self::$calls[] = [
+            'model_id' => $model->getKey(),
+            'payload' => $payload,
+            'task_id' => $task->getKey(),
+            'method' => 'run',
+        ];
+    }
+}

--- a/tests/HasTasksTest.php
+++ b/tests/HasTasksTest.php
@@ -2,22 +2,153 @@
 
 namespace Michal78\Tasks\Tests;
 
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
 use Michal78\Tasks\Models\Task;
+use Michal78\Tasks\Models\TaskLog;
+use Michal78\Tasks\Tests\Fixtures\SampleAction;
+use Michal78\Tasks\Tests\Fixtures\SampleEvent;
+use Michal78\Tasks\Tests\Fixtures\SampleService;
 
 class HasTasksTest extends TestCase
 {
-    public function test_model_can_create_and_retrieve_tasks()
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SampleAction::$calls = [];
+        SampleService::$calls = [];
+    }
+
+    public function test_model_can_schedule_tasks(): void
     {
         $user = User::create(['name' => 'Test User']);
 
-        $task = $user->addTask(['name' => 'Test Task']);
+        $task = $user->scheduleActionTask(
+            name: 'Action Task',
+            actionClass: SampleAction::class,
+            runAt: now()->addMinute(),
+        );
 
         $this->assertInstanceOf(Task::class, $task);
-        $this->assertEquals($user->id, $task->owner_id);
-        $this->assertEquals(User::class, $task->owner_class);
-
+        $this->assertSame($user->id, $task->taskable_id);
+        $this->assertSame(User::class, $task->taskable_type);
+        $this->assertSame(Task::TYPE_ACTION, $task->type);
         $this->assertCount(1, $user->tasks);
-        $this->assertTrue($user->tasks->first()->is($task));
-        $this->assertCount(1, $user->pendingTasks());
+    }
+
+    public function test_due_command_task_passes_model_to_command(): void
+    {
+        $user = User::create(['name' => 'Command User']);
+
+        $user->scheduleCommandTask(
+            name: 'Command Task',
+            command: 'tasks:test-command',
+            runAt: now()->subMinute(),
+            payload: ['--flag' => 'ok'],
+        );
+
+        Artisan::call('tasks:run-due');
+
+        $this->assertSame(User::class, app('task_test.last_command_model_type'));
+        $this->assertSame((string) $user->id, app('task_test.last_command_model_id'));
+        $this->assertSame('ok', app('task_test.last_command_flag'));
+    }
+
+    public function test_due_action_task_receives_model_payload_and_task(): void
+    {
+        $user = User::create(['name' => 'Action User']);
+
+        $task = $user->scheduleActionTask(
+            name: 'Action Task',
+            actionClass: SampleAction::class,
+            runAt: now()->subMinute(),
+            payload: ['token' => 'abc'],
+        );
+
+        Artisan::call('tasks:run-due');
+
+        $this->assertCount(1, SampleAction::$calls);
+        $this->assertSame($user->id, SampleAction::$calls[0]['model_id']);
+        $this->assertSame('abc', SampleAction::$calls[0]['payload']['token']);
+        $this->assertSame($task->id, SampleAction::$calls[0]['task_id']);
+        $this->assertSame(Task::STATUS_SUCCEEDED, $task->fresh()->status);
+    }
+
+    public function test_due_event_task_dispatches_event_with_model(): void
+    {
+        Event::fake([SampleEvent::class]);
+        $user = User::create(['name' => 'Event User']);
+
+        $task = $user->scheduleEventTask(
+            name: 'Event Task',
+            eventClass: SampleEvent::class,
+            runAt: now()->subMinute(),
+            payload: ['source' => 'test'],
+        );
+
+        Artisan::call('tasks:run-due');
+
+        Event::assertDispatched(SampleEvent::class, function (SampleEvent $event) use ($task, $user) {
+            return $event->model->is($user)
+                && $event->task->is($task)
+                && $event->payload['source'] === 'test';
+        });
+    }
+
+    public function test_due_service_task_calls_configured_method(): void
+    {
+        $user = User::create(['name' => 'Service User']);
+
+        $user->scheduleServiceTask(
+            name: 'Service Task',
+            serviceClass: SampleService::class,
+            runAt: now()->subMinute(),
+            payload: ['service' => true],
+            method: 'run',
+        );
+
+        Artisan::call('tasks:run-due');
+
+        $this->assertCount(1, SampleService::$calls);
+        $this->assertSame($user->id, SampleService::$calls[0]['model_id']);
+        $this->assertTrue(SampleService::$calls[0]['payload']['service']);
+    }
+
+    public function test_it_logs_task_runs_when_enabled(): void
+    {
+        config()->set('laravel-tasks.logging.enabled', true);
+        $user = User::create(['name' => 'Log User']);
+
+        $task = $user->scheduleServiceTask(
+            name: 'Log Task',
+            serviceClass: SampleService::class,
+            runAt: now()->subMinute(),
+        );
+
+        Artisan::call('tasks:run-due');
+
+        $log = TaskLog::query()->where('task_id', $task->id)->first();
+
+        $this->assertNotNull($log);
+        $this->assertSame(Task::STATUS_SUCCEEDED, $log->status);
+        $this->assertNotNull($log->started_at);
+        $this->assertNotNull($log->finished_at);
+    }
+
+    public function test_it_skips_task_logs_when_disabled(): void
+    {
+        config()->set('laravel-tasks.logging.enabled', false);
+        $user = User::create(['name' => 'No Log User']);
+
+        $user->scheduleServiceTask(
+            name: 'No Log Task',
+            serviceClass: SampleService::class,
+            runAt: now()->subMinute(),
+        );
+
+        Artisan::call('tasks:run-due');
+
+        $this->assertDatabaseCount('task_logs', 0);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Michal78\Tasks\Tests;
 
 use Orchestra\Testbench\TestCase as Orchestra;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
 use Michal78\Tasks\TasksServiceProvider;
 
@@ -21,6 +22,12 @@ abstract class TestCase extends Orchestra
 
         // run package migrations
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+        Artisan::command('tasks:test-command {--model-type=} {--model-id=} {--flag=}', function () {
+            app()->instance('task_test.last_command_model_type', (string) $this->option('model-type'));
+            app()->instance('task_test.last_command_model_id', (string) $this->option('model-id'));
+            app()->instance('task_test.last_command_flag', (string) $this->option('flag'));
+        });
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
## Summary
- refactor package for Laravel 11/12 + PHP 8.2 and switch to scheduled model task execution
- add support for command, action, event, and service task types with model injection
- add due-task runner (tasks:run-due) and execution pipeline with status/error tracking
- add optional task_logs persistence for task run status and timestamps
- rewrite README with the new API and scheduler integration
- replace tests to cover all task types and logging behavior

## Testing
- composer test